### PR TITLE
added CORS support for /signup and /getNurseDailyTasks/ endpoints

### DIFF
--- a/src/main/java/com/neonatal/backend/controllers/RegistrationController.java
+++ b/src/main/java/com/neonatal/backend/controllers/RegistrationController.java
@@ -37,6 +37,7 @@ public class RegistrationController {
      */
     
    // Show Register page.
+   @CrossOrigin(origins = "*")
    @RequestMapping(value = "/signup", method = RequestMethod.POST)
    public String viewRegister(@RequestBody User user) {
 	   String jwtToken;

--- a/src/main/java/com/neonatal/backend/controllers/RulesController.java
+++ b/src/main/java/com/neonatal/backend/controllers/RulesController.java
@@ -105,6 +105,7 @@ public class RulesController {
 
     }
     
+    @CrossOrigin(origins = "*")
     @RequestMapping(value = "/getNurseDailyTasks/", method = RequestMethod.GET)
 	public List<NurseTasks> getNurseTasks() {
 		List<NurseTasks> nurseTasksList = null;


### PR DESCRIPTION
I added the `@CrossOrigin(origins = "*")` decorator to allow CORS from any origin for /signup and  /getNurseDailyTasks/ endpoints

I already tested both endpoints from React, full integration.